### PR TITLE
New feature

### DIFF
--- a/PushApi/Workers/AndroidSender.php
+++ b/PushApi/Workers/AndroidSender.php
@@ -26,6 +26,12 @@ $queue = new QueueController();
  */
 $data = $queue->getFromQueue(QueueController::ANDROID);
 while ($data != null) {
+    // If message is outdated, it is discard and another one is get
+    if (isset($data->timeToLive) && (strtotime($data->timeToLive) <= strtotime(Date("Y-m-d h:i:s a")))) {
+        $data = $queue->getFromQueue(QueueController::ANDROID);
+        continue;
+    }
+
     // Checking if message has got delay time and if it can be sent or if it is not the time yet
     if (isset($data->delay) && (strtotime($data->delay) > strtotime(Date("Y-m-d h:i:s a")))) {
         // Add the notification to the queue again

--- a/PushApi/Workers/EmailSender.php
+++ b/PushApi/Workers/EmailSender.php
@@ -30,6 +30,12 @@ $queue = new QueueController();
  */
 $data = $queue->getFromQueue(QueueController::EMAIL);
 while ($data != null) {
+    // If message is outdated, it is discard and another one is get
+    if (isset($data->timeToLive) && (strtotime($data->timeToLive) <= strtotime(Date("Y-m-d h:i:s a")))) {
+        $data = $queue->getFromQueue(QueueController::EMAIL);
+        continue;
+    }
+
     // Checking if message has got delay time and if it can be sent or if it is not the time yet
     if (isset($data->delay) && (strtotime($data->delay) > strtotime(Date("Y-m-d h:i:s a")))) {
         // Add the notification to the queue again


### PR DESCRIPTION
+ Added 'time_to_live' to send params. By default, messages have a TTL of one day. This is done in order to avoid send messages when workers fail and they are reactivated late (for example). It is better no notification than a late notification.